### PR TITLE
ci: pull request and main preview deployment with cloudflare pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,35 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
+
+  build_deploy:
+    runs-on: ubuntu-latest
+    needs: typecheck
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy ./dist --project-name=cv-generator --branch=${{ github.ref_name }}


### PR DESCRIPTION
- PR and main preview deployment to CloudFlare Pages adding the deployment link as a comment to the respective PR.
- After the merge is approved, the main branch is deployed to production.

Requirements:

1. Create a CloudFlare API Token:
Access the profile; go to API Tokens; create a custom token with the following permissions: (account - Cloudflare Pages - edit) and (zone - clean cache - clean).

2. Add Cloudflare API_TOKEN and ACCOUNT_ID as secrets in the base GitHub repository.

3. Create a project on Cloudflare Pages. The name given to the project in CloudFlare Pages must be the same used in the deploy action script `pages deploy dist --project-name=<CloudFlare_Pages_Project_Name>`

4. The file wrangler.toml is used for manual deployments if necessary; it also needs the name of the project in CloudFlare Pages. 