### PR TITLE
feat: handle profile image display logic

### DIFF
--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -21,6 +21,7 @@ type Education = {
 
 type Data = {
   profile: {
+    shouldDisplayProfileImage: boolean;
     lines: string[];
     links: ProfileLinkProps[];
   };
@@ -29,10 +30,16 @@ type Data = {
   education: Education[];
 };
 
-const ProfileHeader = ({ lines, links }: Data["profile"]) => {
+const ProfileHeader = ({
+  lines,
+  links,
+  shouldDisplayProfileImage,
+}: Data["profile"]) => {
   return (
     <div className="profile__header">
-      <ProfileImage circular={true} border={true} />
+      {shouldDisplayProfileImage && (
+        <ProfileImage circular={true} border={true} />
+      )}
       <div className="profile__header__lines">
         {lines.map((line, index) => (
           <p key={index}>{line}</p>

--- a/src/data.json
+++ b/src/data.json
@@ -157,6 +157,7 @@
     }
   ],
   "profile": {
+    "shouldDisplayProfileImage": false,
     "lines": [
       "Ancient Rome, Roman Empire",
       "Roman",


### PR DESCRIPTION
Adds "shouldDisplayProfileImage" to "data.json" to control profile image visibility.

Fixes #47 