### PR TITLE
feat: add optional `name` prop to ProfileLinks

### DIFF
--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -46,9 +46,9 @@ const ProfileHeader = ({
         ))}
       </div>
       <div className="profile__header__links">
-        {links.map((link, index) => (
-          <ProfileLink key={index} type={link.type} link={link.link} />
-        ))}
+        {links.map((link, index) => {
+          return <ProfileLink key={index} {...link} />;
+        })}
       </div>
     </div>
   );

--- a/src/components/Profile/ProfileLink/ProfileLink.tsx
+++ b/src/components/Profile/ProfileLink/ProfileLink.tsx
@@ -7,9 +7,11 @@ export type ProfileLinkProps = {
   type: string;
   /** Please, use without https:// */
   link: string;
+  /** Custom display name for the link, if not provided the link address will be displayed */
+  name?: string;
 };
 
-const ProfileLink = ({ type, link }: ProfileLinkProps) => {
+const ProfileLink = ({ type, link, name }: ProfileLinkProps) => {
   let icon;
 
   switch (type) {
@@ -34,7 +36,7 @@ const ProfileLink = ({ type, link }: ProfileLinkProps) => {
     <div className="profile__header__link">
       <a href={`https://${link}`} target="_blank" rel="noopener noreferrer">
         {icon}
-        <span>{type}</span>
+        <span>{name || type}</span>
       </a>
     </div>
   );


### PR DESCRIPTION
# Overview

Allow Custom Link Names in Profile

This change adds support for naming profile links, instead of relying solely on their type.

I prefer urls fully visible so that if the resume is printed the information from the links isn't lost.

<details>
<summary>Example</summary>

### Previous

```json
"links": [
      {
        "type": "LinkedIn",
        "link": "linkedin.com/in/example/",
      },
      {
        "type": "GitHub",
        "link": "github.com/example",
      },
      {
        "type": "Website",
        "link": "https://www.example.com",
      },
      {
        "type": "Bluesky",
        "link": "bsky.app/bluesky-example.bsky",
      }
    ]
```

#### Now allows


```json
"links": [
      {
        "type": "LinkedIn",
        "link": "linkedin.com/in/example/",
        "name": "linkedin.com/in/example/"
      },
      {
        "type": "GitHub",
        "link": "github.com/example",
        "name": "github.com/example"
      },
      {
        "type": "Website",
        "link": "https://www.example.com",
        "name": "exmaple.com"
      },
      {
        "type": "Bluesky",
        "link": "bsky.app/bluesky-example.bsky",
        "name": "bsky.app/bluesky-example.bsky"
      }
    ]
```

</details>
